### PR TITLE
ENH: updates for 2023

### DIFF
--- a/app/lib/paper_file.rb
+++ b/app/lib/paper_file.rb
@@ -74,11 +74,10 @@ class PaperFile
 
     if Dir.exist? search_path
       Find.find(search_path).each do |path|
-        # the example papers are 00_vanderwalt and 00_bibderwalt
-        unless path.include?("00_vanderwalt") || path.include?("00_bibderwalt")
-          # currently, SciPy only supports restructered text, although hopefully
-          # this will change in the future
-          if path =~ /.*\.rst$/
+        # the example papers are 00_texderwalt and 00_bibderwalt
+        unless path.include?("00_texderwalt") || path.include?("00_bibderwalt")
+          # currently, SciPy supports LaTeX and reStructuredText
+          if path =~ /papers.*\.tex$|papers.*\.rst$/
             puts "found paper path #{path}"
             paper_path = path
             break

--- a/config/settings-development.yml
+++ b/config/settings-development.yml
@@ -9,7 +9,6 @@ buffy:
       - deniederhut
       - mepa
       - cbcunc
-      - stargaser
   responders:
     help:
     hello:
@@ -21,7 +20,7 @@ buffy:
           command: code of conduct
           description: Show our community Code of Conduct and Guidelines
           messages:
-            - "Our CoC: https://www.scipy2021.scipy.org/code-of-conduct"
+            - "Our CoC: https://www.scipy2023.scipy.org/code-of-conduct"
             - "Reports of abusive or harassing behavior may be reported to scipy@enthought.com"
     list_of_values:
       - reviewers:

--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -9,7 +9,6 @@ buffy:
       - deniederhut
       - mepa
       - cbcunc
-      - stargaser
   responders:
     help:
     hello:
@@ -21,7 +20,7 @@ buffy:
           command: code of conduct
           description: Show our community Code of Conduct and Guidelines
           messages:
-            - "Our CoC: https://www.scipy2021.scipy.org/code-of-conduct"
+            - "Our CoC: https://www.scipy2023.scipy.org/code-of-conduct"
             - "Reports of abusive or harassing behavior may be reported to scipy@enthought.com"
     list_of_values:
       - reviewers:


### PR DESCRIPTION
In 2023, SciPy Proceedings supports (in alpha) LaTeX submissions. Also, there are some reStructuredText files (e.g., reviews/invite-abstract-reviews.rst) in the scipy_proceedings repo that buffy was finding instead of the .rst file in papers/ dir. 

This PR updates the SciPy Proceedings bot to 
- locate the correct paper path ([test-rst](https://github.com/scipy-conference/scipy_proceedings_test/pull/13#issuecomment-1560482175), [test-tex](https://github.com/scipy-conference/scipy_proceedings_test/pull/14#issuecomment-1560483300))
- display the 2023 code of conduct link [(test)](https://github.com/scipy-conference/scipy_proceedings_test/pull/13#issuecomment-1560479569)
- 2023 editors

Closes https://github.com/scipy-conference/buffy/issues/5